### PR TITLE
Implement flats index page to display all flats

### DIFF
--- a/app/controllers/flats_controller.rb
+++ b/app/controllers/flats_controller.rb
@@ -1,0 +1,5 @@
+class FlatsController < ApplicationController
+  def index
+    @flats = Flat.all
+  end
+end

--- a/app/models/flat.rb
+++ b/app/models/flat.rb
@@ -1,0 +1,5 @@
+class Flat < ApplicationRecord
+  belongs_to :user
+
+  validates :name, :description, :price_per_night, :address, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,5 +2,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+        :recoverable, :rememberable, :validatable
+
+  has_many :flats, dependent: :destroy
 end

--- a/app/views/flats/index.html.erb
+++ b/app/views/flats/index.html.erb
@@ -1,0 +1,14 @@
+<h1>All Flats</h1>
+
+<ul>
+  <% @flats.each do |flat| %>
+    <li>
+      <strong><%= flat.name %></strong><br>
+      <%= flat.description %><br>
+      <%= flat.price_per_night %> per night
+    </li>
+  <% end %>
+</ul>
+
+<!-- Link back to the homepage -->
+<%= link_to 'Back to Homepage', root_path %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,2 +1,5 @@
 <h1>Pages#home</h1>
 <p>Find me in app/views/pages/home.html.erb</p>
+
+<!-- Link to the flats index page -->
+<%= link_to 'View All Flats', flats_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "pages#home"
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
-  # Defines the root path route ("/")
-  # root "posts#index"
+  resources :flats, only: [:index]
 end

--- a/db/migrate/20250223013528_create_flats.rb
+++ b/db/migrate/20250223013528_create_flats.rb
@@ -1,0 +1,14 @@
+class CreateFlats < ActiveRecord::Migration[7.1]
+  def change
+    create_table :flats do |t|
+      t.string :name
+      t.references :user, null: false, foreign_key: true
+      t.text :description
+      t.text :amenities
+      t.integer :price_per_night
+      t.string :address
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_22_205034) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_23_013528) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "flats", force: :cascade do |t|
+    t.string "name"
+    t.bigint "user_id", null: false
+    t.text "description"
+    t.text "amenities"
+    t.integer "price_per_night"
+    t.string "address"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_flats_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -26,4 +38,5 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_22_205034) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "flats", "users"
 end

--- a/test/controllers/flats_controller_test.rb
+++ b/test/controllers/flats_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FlatsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/flat_test.rb
+++ b/test/models/flat_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FlatTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
- Created the `index` page for flats where users can see a list of all available flats.
- Added an `index` action to the `FlatsController` to retrieve all flats from the database.
- Displayed each flat's name, description, and price per night in an unordered list on the `index.html.erb` view.
- Added a link back to the homepage for easy navigation.

This feature allows users to see all the flats listed in the app and navigate back to the homepage.
